### PR TITLE
deprecate 'inject' command in favor of 'envFrom' configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,45 @@ pip3 install kubestash
 ## usage
 
 ```
-usage: kubestash [-h] {inject,push} ...
-
-push a Credstash table to a Kubernetes secret
+usage: kubestash push [-h] [-p PROXY] [-v] [--trace] [-f] [-n NAMESPACE]
+                        [-l] [-c CONTEXT] [-r REGION]
+                        table secret
 
 positional arguments:
-  {inject,push}
-    inject       inject env variables into a Kubernetes deployment manifest,
-                 taken from a Kubernetes secret
-    push         push values from a Credstash table to a Kubernetes secret
+  table                 Credstash table you want to pull values from
+  secret                Kubernetes secret you want to push values in
 
 optional arguments:
-  -h, --help     show this help message and exit
+  -h, --help            show this help message and exit
+  -p PROXY, --proxy PROXY
+                        hostname of a kubernetes apiserver to use, for
+                        example: --proxy 127.0.0.1:8080
+  -v, --verbose         verbose output
+  --trace               show the full stack trace when an SSLError happens
+  -f, --force           replace a secret if it already exists
+  -n NAMESPACE, --namespace NAMESPACE
+                        kubernetes namespace
+  -l, --lowercase       For SECRET keys, lowercase and convert "_" to "-"
+                        (DNS_SUBDOMAIN). Useful for compatibility with older
+                        Kubernetes versions. (deprecated).
+  -c CONTEXT, --context CONTEXT
+                        kubernetes context
+  -r REGION, --region REGION
+                        aws region
+
 ```
+
+## adding envs to your deployment manifest
+
+add this to your container manifest to import your secret as environment variables
+
+```yaml
+envFrom:
+- secretRef:
+    name: secret-name
+```
+
+See [test/example.deploy.yaml](test/example.deploy.yaml) for an example of this.
 
 ## use case
 
@@ -41,26 +67,24 @@ Just run:
 
 and you'll have a Kubernetes SECRET which maps 1:1 with your Credstash TABLE.
 
-Instead of writing a ton of yaml to inject your secrets into each container, simply run:
-
-`kubestash inject SECRET DEPLOYMENT`
-
-and each container in DEPLOYMENT will now have each key-value from SECRET.
-
 
 ## secret key constraints
 
 Keys must consist of alphanumeric characters, ‘-‘, ‘_’ or ‘.’. [1]
 
-So when you run `credstash -t=table put KEY VALUE`, you should take care that KEY meets this constraint.
+Environment variable names must consist solely of uppercase letters, digits, and the '_' (underscore). [2]
 
-In older versions of Kubernetes, secret keys had to conform to DNS_SUBDOMAIN. [2]
+So when you run `credstash -t=table put KEY VALUE`, you should take care that KEY meets these constraints.
+
+In older versions of Kubernetes, secret keys had to conform to DNS_SUBDOMAIN. [3]
 
 For this purpose, the `-l --lowercase` flag is present to help you convert your keys if necessary.
 
 [1] https://kubernetes.io/docs/concepts/configuration/secret/
 
-[2] https://github.com/kubernetes/community/blob/master/contributors/design-proposals/identifiers.md
+[2] http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html
+
+[3] https://github.com/kubernetes/community/blob/master/contributors/design-proposals/identifiers.md
 
 
 ## known issues

--- a/kubestash/__init__.py
+++ b/kubestash/__init__.py
@@ -10,7 +10,6 @@ import credstash
 
 # TODO: args.profile, args.arn
 # TODO: args.version
-# TODO: inject should support editing a local file, for those who version control their Kubernetes manifests
 
 
 def base_parser():
@@ -44,7 +43,7 @@ def base_parser():
                         action='store_true',
                         help='For SECRET keys, lowercase and convert "_" to "-" (DNS_SUBDOMAIN). '
                              'Useful for compatibility with older Kubernetes versions. '
-                             '(deprecated).')
+                             '(DEPRECATED).')
     return parser
 
 
@@ -53,7 +52,7 @@ def add_parser_inject(parent):
     parser = parent.add_parser('inject',
                                parents=[base_parser()],
                                help='inject env variables into a Kubernetes deployment manifest, '
-                                    'taken from a Kubernetes secret')
+                                    'taken from a Kubernetes secret (DEPRECATED; see README.md, use envFrom instead)')
     parser.add_argument('secret',
                         action='store',
                         type=str,
@@ -312,7 +311,7 @@ def cmd_inject(args):
         }
     }
     kube_patch_deployment(args, data)
-    print('Injected environment variables into deployment: "{deployment}" '
+    print('inject is DEPRECATED; see README.md, use envFrom instead)\n\nInjected environment variables into deployment: "{deployment}" '
           'from secret: "{secret}"'.format(deployment=args.deployment, secret=args.secret))
 
 

--- a/test/example.deploy.yaml
+++ b/test/example.deploy.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example
+  labels:
+    app: example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: example
+  template:
+    metadata:
+      labels:
+        app: example
+    spec:
+      containers:
+      - name: example
+        image: alpine:3.6
+
+        # print out the environment variables and then sleep
+        command: ["/bin/sh", "-c"]
+        args: ['env && sleep 10000']
+
+        # takes everything from a secret called "kubestash" and puts it in env
+        envFrom:
+        - secretRef:
+            name: kubestash
+
+        # you can also override variables if you need to
+        # deviate from whats in secrets
+        env:
+        - name: FOO
+          value: REALBAR


### PR DESCRIPTION
## Summary

As @captn3m0 pointed out in https://github.com/af-inet/kubestash/issues/2, there is a better way to add environment variables to deployment manifests.

## Changes
- general README.md updates
- deprecate the `inject` command
- add an example of `envFrom` usage in deployment manifests