### PR TITLE
Adds --uppercase flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ optional arguments:
   -f, --force           replace a secret if it already exists
   -n NAMESPACE, --namespace NAMESPACE
                         kubernetes namespace
+  -u, --uppercase       For lowercase keys in credstash, convert them 
+                        to UPPER_CASE environment variables
   -l, --lowercase       For SECRET keys, lowercase and convert "_" to "-"
                         (DNS_SUBDOMAIN). Useful for compatibility with older
                         Kubernetes versions. (deprecated).

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `-u --uppercase` flag to convert `lower-case` keys in credstash to `LOWER_CASE` secrets
+
 ## [1.0.0] - 2018-04-03
 ### Added
 - daemon mode

--- a/kubestash/__init__.py
+++ b/kubestash/__init__.py
@@ -46,7 +46,7 @@ def base_parser():
                         help='For SECRET keys, lowercase and convert "_" to "-" (DNS_SUBDOMAIN). '
                              'Useful for compatibility with older Kubernetes versions. '
                              '(DEPRECATED).')
-    parser.add_argument('-u', '--uppercase',
+    parser.add_argument('-U', '--uppercase',
                         dest='uppercase',
                         action='store_true',
                         help='For environment variable keys, uppercase and convert dashes to undescores.'

--- a/kubestash/__init__.py
+++ b/kubestash/__init__.py
@@ -46,6 +46,11 @@ def base_parser():
                         help='For SECRET keys, lowercase and convert "_" to "-" (DNS_SUBDOMAIN). '
                              'Useful for compatibility with older Kubernetes versions. '
                              '(DEPRECATED).')
+    parser.add_argument('-u', '--uppercase',
+                        dest='uppercase',
+                        action='store_true',
+                        help='For environment variable keys, uppercase and convert dashes to undescores.'
+                        'Useful if your keys in credstash are in lowercase')
     return parser
 
 
@@ -189,9 +194,15 @@ def dns_subdomain(string):
     return string.replace('_', '-').lower()
 
 
-def maybe_dns_subdomain(args, string):
-    """Only convert to dns_subdomain if the --lowercase flag is set. """
-    return dns_subdomain(string) if args.lowercase else string
+def generate_key(args, string):
+    """Only convert to dns_subdomain if the --lowercase flag is set. 
+       Only convert to ENV_VAR if the --uppercase flag is set."""
+    if args.uppercase:
+        return reverse_dns_subdomain(string)
+    elif args.lowercase:
+        dns_subdomain(string)
+        pass
+    return string
 
 
 def reverse_dns_subdomain(string):
@@ -216,7 +227,7 @@ def kube_init_secret(args, data):
     # https://github.com/kubernetes-incubator/client-python/blob/master/kubernetes/docs/V1Secret.md
     # api_version, data, kind, metadata, string_data, type
     converted_data = {
-        maybe_dns_subdomain(args, key): base64.b64encode(data[key].encode('utf-8')).decode('utf-8')
+        generate_key(args, key): base64.b64encode(data[key].encode('utf-8')).decode('utf-8')
         for key in data
     }
     metadata = kubernetes.client.V1ObjectMeta(name=args.secret)

--- a/kubestash/__init__.py
+++ b/kubestash/__init__.py
@@ -200,8 +200,7 @@ def generate_key(args, string):
     if args.uppercase:
         return reverse_dns_subdomain(string)
     elif args.lowercase:
-        dns_subdomain(string)
-        pass
+        return dns_subdomain(string)
     return string
 
 
@@ -470,7 +469,6 @@ def main():
         sys.exit(1)
 
     kubernetes.config.load_kube_config(config_file=config_file, context=args.context)
-
 
     # override the host if the user passes in a --proxy
     if args.proxy and (len(args.proxy) == 1):


### PR DESCRIPTION
We need this because all of our secrets are lowercase with dashes. We have keys that were never meant to be directly used as environment variables and had built [tooling that converted it to environment variables](https://pypi.python.org/pypi/razorpay.alohomora). However, with kubernetes, we'd like to use our existing tables (we have one table per env/app combination) and the uppercase flag will help us a lot in this.

The credstash default docs also use lowercase keys, albeit with dots as separators.