### PR TITLE
Adds pushall support

### DIFF
--- a/kubestash/__init__.py
+++ b/kubestash/__init__.py
@@ -662,12 +662,15 @@ def cmd_daemonall(args):
         response = client.get_records(ShardIterator=shard_iterator, Limit=10)
 
         if len(response['Records']) > 0:
-            key = response['Records'][0]['dynamodb']['Keys']['name']['S']
-            if args.verbose:
-                print("detected DynamoDB changes, running push command...")
-            argscopy = copy.copy(args)
-            argscopy.secretname = key
-            cmd_pushall(argscopy)
+            for record in:
+                response['Records']
+                key = record['dynamodb']['Keys']['name']['S']
+                if args.verbose:
+                    print("detected DynamoDB changes, running push command...")
+                argscopy = copy.copy(args)
+                argscopy.secretname = key
+                cmd_pushall(argscopy)
+
         time.sleep(args.interval)
 
 

--- a/kubestash/__init__.py
+++ b/kubestash/__init__.py
@@ -1,7 +1,6 @@
 import argparse
 import base64
 import sys
-import pprint
 import time
 import urllib3
 import ssl
@@ -9,6 +8,7 @@ import os
 import kubernetes
 import credstash
 import boto3
+import copy
 from collections import namedtuple
 
 
@@ -651,7 +651,7 @@ def cmd_daemonall(args):
     if args.verbose:
         print("checking DynamoDB Stream for changes...")
 
-    response = client.get_records(ShardIterator=shard_iterator, Limit=1)
+    response = client.get_records(ShardIterator=shard_iterator, Limit=10)
 
     while True:
         shard_iterator = response['NextShardIterator']
@@ -659,14 +659,14 @@ def cmd_daemonall(args):
         if args.verbose:
             print("checking DynamoDB Stream for changes...")
 
-        response = client.get_records(ShardIterator=shard_iterator, Limit=1)
+        response = client.get_records(ShardIterator=shard_iterator, Limit=10)
 
         if len(response['Records']) > 0:
             key = response['Records'][0]['dynamodb']['Keys']['name']['S']
             if args.verbose:
                 print("detected DynamoDB changes, running push command...")
             argscopy = copy.copy(args)
-            argscopy.secretkeyname = key
+            argscopy.secretname = key
             cmd_pushall(argscopy)
         time.sleep(args.interval)
 


### PR DESCRIPTION
As discussed in #2, this adds supports for a `pushall` command that syncs an entire table with a cluster basis the naming scheme for credstash entries.

This is how our test table looks:

![image](https://user-images.githubusercontent.com/584253/39051600-c89038f6-44c6-11e8-9791-67e7472116b7.png)

Every entry is 3 parts:

1. kubernetes namespace
2. kubernetes secret-name
3. ENV_VAR name inside the secret

We are running it with `--uppercase` flag as well, which is why some entries are lowercase. Also adds a `daemonall` command that calls `pushall` on updates. However, it takes care to run `getSecret` instead of `getAllSecrets` on streaming updates. This saves on dynamoDB fetch costs.